### PR TITLE
set default hz to 0 instead of random int

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+displayplacer: displayplacer.c header.h
+	gcc -o displayplacer displayplacer.c -framework IOKit -framework ApplicationServices -Wno-deprecated-declarations

--- a/displayplacer.c
+++ b/displayplacer.c
@@ -51,8 +51,11 @@ int main(int argc, char * argv[])
                     resToken = strtok_r(NULL, "x", &resSavePtr);
                     screenConfigs[i].height = atoi(resToken);
                     resToken = strtok_r(NULL, "x", &resSavePtr);
-                    if (resToken)
+                    if (resToken) {
                         screenConfigs[i].hz = atoi(resToken);
+                    } else {
+                        screenConfigs[i].hz = 0;
+                    }
                     
                     break;
                 case 's': //scaling


### PR DESCRIPTION
If you leave hz off of the res string, it will retain whatever random int value was in memory at the point it was declared, which caused check for existence of hz to succeed.  Instead, default hz to 0.

Also added a Makefile for the build command listed in the readme.

The recompiled binary is not part of the PR.  If approved you can have a trustworthy source (yourself) build and push that.