### PR TITLE
Add error details to rotation error message

### DIFF
--- a/displayplacer.c
+++ b/displayplacer.c
@@ -419,7 +419,7 @@ bool rotateScreen(CGDirectDisplayID screenId, char* screenUUID, int degree) {
     int retVal = IOServiceRequestProbe(service, options);
 
     if (retVal != 0) {
-        fprintf(stderr, "Error rotating screen %s\n", screenUUID);
+        fprintf(stderr, "Error rotating screen %s: %s, code: 0x%x\n", screenUUID, mach_error_string(retVal), retVal);
         return false;
     }
 


### PR DESCRIPTION
If screen rotation fails, the user is not given any information why it failed. This commit adds the mach error string and code to the error message.
Example output:
Error rotating screen 74F4484D-FF93-DFFA-0857-D6964E3302DB: (ipc/send) invalid destination port, code: 0x10000003