### PR TITLE
addressing display by serialID

### DIFF
--- a/displayplacer.c
+++ b/displayplacer.c
@@ -62,6 +62,28 @@ int main(int argc, char* argv[]) {
                     screenConfigs[i].mirrorCount = j;
 
                     break;
+                case 'S': //serial
+                    propToken = strtok_r(NULL, ":", &propSavePtr);
+                    UInt32 serialID = atoi(propToken);
+                    char persistentID[UUID_SIZE];
+                    getUUIDfromSerial(serialID, persistentID);
+                    strlcpy(screenConfigs[i].uuid, persistentID, sizeof(screenConfigs[i].uuid));
+
+                    idToken = strtok_r(propToken, "+", &propToken);
+                    j = 0;
+                    while ((idToken = strtok_r(propToken, "+", &propToken))) {
+                        UInt32 serialMirrorID = atoi(idToken);
+                        char persistentMirrorID[UUID_SIZE];
+                        getUUIDfromSerial(serialMirrorID, persistentMirrorID);
+                        strlcpy(screenConfigs[i].mirrorUUIDs[j], persistentMirrorID, sizeof(screenConfigs[i].mirrorUUIDs[j]));
+                        j++;
+                        
+                        if (j > 127) {
+                            fprintf(stderr, "Current code only supports 128 screens mirroring. Please execute `displayplacer --version` for info on contacting the developer to change this.\n");
+                        }
+                    }
+
+                    break;
                 case 'r': //res
                     propToken = strtok_r(NULL, ":", &propSavePtr);
 
@@ -289,9 +311,11 @@ void listScreens() {
         CGSGetDisplayModeDescriptionOfLength(curScreen, curModeId, &curMode, 0xD4);
 
         char curScreenUUID[UUID_SIZE];
+        UInt32 serialID = CGDisplaySerialNumber(screenList[i]);
         CFStringGetCString(CFUUIDCreateString(kCFAllocatorDefault, CGDisplayCreateUUIDFromDisplayID(curScreen)), curScreenUUID, sizeof(curScreenUUID), kCFStringEncodingUTF8);
         printf("Persistent screen id: %s\n", curScreenUUID);
         printf("Contextual screen id: %i\n", curScreen);
+        printf("Serial screen id: %u\n", serialID);
 
         if (CGDisplayIsBuiltin(curScreen)) {
             printf("Type: MacBook built in screen\n");
@@ -574,3 +598,24 @@ bool configureOrigin(CGDisplayConfigRef configRef, CGDirectDisplayID screenId, c
 
     return true;
 }
+
+
+void getUUIDfromSerial(UInt32 serialID, char* persistentUUID){
+    CGDisplayCount screenCount;
+    CGGetOnlineDisplayList(INT_MAX, NULL, &screenCount); //get number of online screens and store in screenCount
+
+    CGDirectDisplayID screenList[screenCount];
+    CGGetOnlineDisplayList(INT_MAX, screenList, &screenCount);
+
+    CGDirectDisplayID contextualID = 0;  //contextual
+
+    for (int i = 0; i < screenCount; i++) {
+        CGDirectDisplayID curUUID = screenList[i];
+        UInt32 curSerial = CGDisplaySerialNumber(curUUID);
+        if(curSerial == serialID){
+            contextualID = curUUID;
+        }
+    }
+    CFStringGetCString(CFUUIDCreateString(kCFAllocatorDefault, CGDisplayCreateUUIDFromDisplayID(contextualID)), persistentUUID, UUID_SIZE * sizeof(char), kCFStringEncodingUTF8);
+}
+

--- a/header.h
+++ b/header.h
@@ -50,6 +50,7 @@ typedef struct
 {
     char uuid[UUID_SIZE];                    //user input display identifier that stays consistent despite GPU or port changes (persistent screen id)
     char mirrorUUIDs[MIRROR_MAX][UUID_SIZE]; //user input display UUIDs that mirror this display
+    UInt32 serialID;                         //user input display serial ID
     CGDirectDisplayID id;                    //display identifier used for Quartz Display Services (contextual screen id)
     CGDirectDisplayID mirrors[MIRROR_MAX];   //display IDs that mirror this display used for Quartz Display Services
     int mirrorCount;                         //number of displays that mirror this display
@@ -71,6 +72,7 @@ void printVersion();
 void listScreens();
 void printCurrentProfile();
 CGDirectDisplayID convertUUIDtoID(char* uuid);
+void getUUIDfromSerial(UInt32 serialID, char* persistentUUID);
 bool validateScreenOnline(CGDirectDisplayID onlineDisplayList[], int screenCount, CGDirectDisplayID screenId, char* screenUUID, bool quietMissingScreen);
 bool isScreenEnabled(CGDirectDisplayID screenId);
 bool rotateScreen(CGDirectDisplayID screenId, char* screenUUID, int degree);


### PR DESCRIPTION
Since the persistent ID takes into account the position in the I/O Kit registry, sometimes the IDs get swapped or change (Issues #89 #83 #77 ...).
Identifying the displays through their serial number should fix those issues
Usage: `displayplacer "S:<serial_num> res:<resolution> ... degree:<degree>"`