### PR TITLE
'mach_error_string' is invalid in C99

### DIFF
--- a/displayplacer.c
+++ b/displayplacer.c
@@ -3,6 +3,7 @@
 
 #include <IOKit/graphics/IOGraphicsLib.h>
 #include <ApplicationServices/ApplicationServices.h>
+#include <mach/mach.h>
 #include <math.h>
 #include <stdio.h>
 #include "header.h"


### PR DESCRIPTION
Adds <mach/mach.h> include to solve issue with compilation under Catalina:
displayplacer.c:495:83: error: implicit declaration of function
      'mach_error_string' is invalid in C99