### PR TITLE
Update README to document how to compile and install the latest code via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/firstcontributions/first-contributions)  
 macOS command line utility to configure multi-display resolutions and arrangements. Essentially XRandR for macOS.
 
-Install via Homebrew with `brew tap jakehilborn/jakehilborn && brew install displayplacer` or visit the [releases](https://github.com/jakehilborn/displayplacer/releases) tab.
+Compile and install the latest code via Homebrew with `brew tap jakehilborn/jakehilborn && brew install --head displayplacer`. Or visit the [releases](https://github.com/jakehilborn/displayplacer/releases) tab to download the latest release. 
 
 #### Usage:
 


### PR DESCRIPTION
**NOTE: This relies on https://github.com/jakehilborn/homebrew-jakehilborn/pull/1 being merged.**

The current github release is very out of date and from 2019. It's missing a few bug fixes. The inaccurate support for "scaling:off" comes to mind.

But instead of complaining about the lack of a recent releases, which are always a pain to update, we can instead just use homebrew to make it easy for users to compile and install the latest version of the code currently on github! This is particularly simple for displayplacer since it has no special build dependencies.  I tested this myself and it worked fine instantly. Considering the pace of commits and relatively stable nature of master, I don't think this introduces too much risk.  

This commit just updates the instructions to tell users to install with `brew install --head displayplacer` instead of `brew install displayplacer`.  Homebrew may require users to install general xcode build tools, but I believe most homebrew users have already done that and homebrew makes it very simple to do so if needed.  This also of course relies on the PR mentioned above also being merged.

(digression: I think `brew install --head ... ` is an under utilized feature of homebrew taps.  It obviates much of the pressure for the maintainer to provide a github release at all)

EDIT: I also noticed this recent PR, https://github.com/jakehilborn/displayplacer/pull/99, where it seems to say the current version of master won't compile on Catalina. I don't have a Catalina system to repro, but assuming it's true then that also should be merged before this so that users compiling on Catalina will still succeed.


