### PR TITLE
Fix: 'mach_error_string' is invalid in C99

### DIFF
--- a/src/DisplayPlacer.c
+++ b/src/DisplayPlacer.c
@@ -1,5 +1,6 @@
 #include <IOKit/graphics/IOGraphicsLib.h>
 #include <ApplicationServices/ApplicationServices.h>
+#include <mach/mach.h>
 #include <math.h>
 #include <stdio.h>
 #include "Header.h"


### PR DESCRIPTION
Adds <mach/mach.h> include to solve issue with compilation under Catalina: displayplacer.c:495:83: error: implicit declaration of function
      'mach_error_string' is invalid in C99