### PR TITLE
Add json output to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Install via Homebrew with `brew install displayplacer` or visit the [releases](h
 
 Show current screen info and possible resolutions: `displayplacer list`
 
+Show current screen info and possible resolutions in json: `displayplacer list --json`
+
 Apply screen config (hz & color_depth are optional): `displayplacer "id:<screenId> res:<width>x<height> hz:<num> color_depth:<num> scaling:<on/off> origin:(<x>,<y>) degree:<0/90/180/270>"`
 
 Apply screen config using mode: `displayplacer "id:<screenId> mode:<modeNum> origin:(<x>,<y>) degree:<0/90/180/270>"`
@@ -23,6 +25,7 @@ Silence errors per-screen using quiet: `displayplacer "id:<screenId> mode:<modeN
 Disable a screen: `displayplacer "id:<screenId> enabled:false"`
 
 #### Instructions:
+
 1. Manually set rotations 1st*, resolutions 2nd, and arrangement 3rd. For extra resolutions and rotations read 'Notes' below.
     - Open System Preferences -> Displays
     - Choose desired screen rotations (use displayplacer for rotating internal MacBook screen).
@@ -32,14 +35,27 @@ Disable a screen: `displayplacer "id:<screenId> enabled:false"`
 2. Use `displayplacer list` to print your current layout's args, so you can create profiles for scripting/hotkeys with [Automator](https://github.com/jakehilborn/displayplacer/issues/13), BetterTouchTool, etc.
 
 #### ScreenIds Switching:
+
 Unfortunately, macOS sometimes changes the persistent screenIds when there are race conditions from external screens waking up in non-determinisic order. If none of the screenId options below work for your setup, please search around in the GitHub Issues for conversation regarding this. Many people have written shell scripts to work around this issue. Recommended discussions are [one](https://github.com/jakehilborn/displayplacer/issues/80), [two](https://github.com/jakehilborn/displayplacer/issues/30), [three](https://github.com/jakehilborn/displayplacer/issues/89), [four](https://github.com/jakehilborn/displayplacer/issues/77), [five](https://github.com/jakehilborn/displayplacer/issues/100), [six](https://github.com/jakehilborn/displayplacer/pull/96).
 
 You can mix and match screenId types across your setup.
+
 - Persistent screenIds usually stay the same. They are recommended for most use cases.
 - Contextual screenIds change when switching GPUs or when cables switch ports. If you notice persistent screenIds switching around, try using the contextual screenIds.
 - Serial screenIds are tied to your display hardware. If the serial screenIds are unique for all of your monitors, use these.
 
+#### JSON output
+
+The `list` subcommand accepts the `--json` parameter to output a valid json structure, which in general is the same as the plain `list` output.
+
+However this structure is completely unformatted and not very human-frienly, if you want to have a more readable output, pipe it into the `jq` tool:
+
+```shell
+displayplacer list --json | jq
+```
+
 #### Notes:
+
 - *`displayplacer list` and system prefs only show resolutions for the screen's current rotation.
 - Use an extra resolution shown in `displayplacer list` by executing `displayplacer "id:<screenId> mode:<modeNum>"`. Some of the resolutions listed do not work. If you select one, displayplacer will default to another working resolution.
 - Rotate your internal MacBook screen by executing `displayplacer "id:<screenId> degree:<0/90/180/270>"`
@@ -50,7 +66,9 @@ You can mix and match screenId types across your setup.
 - screenId is optional if there is only one screen. Rule of thumb is that displayplacer is expecting the entire profile config per screen though, so this may be buggy.
 
 #### Backward Compatability:
+
 `displayplacer list` output changed slightly in v1.4.0. If this broke your scripts, use `displayplacer list --v1.3.0`.
 
 #### Feedback:
+
 Please create a GitHub Issue for any feedback, feature requests, bugs, Homebrew issues, etc. Happy to accept pull requests too!

--- a/src/DisplayPlacer.c
+++ b/src/DisplayPlacer.c
@@ -326,7 +326,7 @@ void listScreens() {
             print_json_start('{', "origin"); // ORIGIN BLOCK
             print_int_val("", "x", "%i", (int) CGDisplayBounds(curScreen).origin.x, true);
             print_int_val("", "y", "%i", (int) CGDisplayBounds(curScreen).origin.y, true);
-            print_str_val("", "main_display", "%s", ((CGDisplayIsMain(curScreen)) ? "true" : "false"), false);
+            print_bool_val("", "main_display", CGDisplayIsMain(curScreen), false);
             print_json_end('}', true); // ORIGIN BLOCK
         }
         if (!print_json) {
@@ -336,9 +336,9 @@ void listScreens() {
             }
             printf("\n");
         } else {
-            print_str_val("", "builtin", "%s", (CGDisplayIsBuiltin(curScreen)) ? "true" : "false", true);
+            print_bool_val("", "builtin", CGDisplayIsBuiltin(curScreen), true);
         }
-        print_str_val("Enabled", "enabled", "%s", isScreenEnabled(curScreen) ? "true" : "false", true);
+        print_bool_val("Enabled", "enabled", isScreenEnabled(curScreen), true);
 
         int modeCount;
         modes_D4* modes;
@@ -362,8 +362,8 @@ void listScreens() {
                 print_int_val("", "y", "%i", (int) CGDisplayPixelsHigh(curScreen), true);
                 print_int_val("", "hz", "%i", mode.derived.freq, true);
                 print_int_val("", "color_depth", "%i", mode.derived.depth, true);
-                print_str_val("", "scaling", "%s", (mode.derived.density == 2.0) ? "true": "false", true);
-                print_str_val("", "current_mode", "%s", (j == curModeId) ? "true": "false", false);
+                print_bool_val("", "scaling", (mode.derived.density == 2.0), true);
+                print_bool_val("", "current_mode", (j == curModeId), false);
                 // print_json_end('}', true);
             } else {
                 printf("  mode %i: res:%dx%d", j, mode.derived.width, mode.derived.height);

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ INSTALL_DATA ?= $(INSTALL) -m 644
 all: displayplacer
 
 displayplacer:
-	$(CC) -I. $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) DisplayPlacer.c Legacy/v130.c -x objective-c MonitorPanel.m -o $@ $< -F./Headers -F/System/Library/PrivateFrameworks -framework IOKit -framework ApplicationServices -framework DisplayServices -framework CoreDisplay -framework OSD -framework MonitorPanel -framework SkyLight $(WARNINGS)
+	$(CC) -I. $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) DisplayPlacer.c printjson.c Legacy/v130.c -x objective-c MonitorPanel.m -o $@ $< -F./Headers -F/System/Library/PrivateFrameworks -framework IOKit -framework ApplicationServices -framework DisplayServices -framework CoreDisplay -framework OSD -framework MonitorPanel -framework SkyLight $(WARNINGS)
 
 .PHONY: debug
 debug: CFLAGS += -g

--- a/src/printjson.c
+++ b/src/printjson.c
@@ -44,6 +44,21 @@ void print_str_val(const char *name, const char *json_name, const char *valfmt, 
     printf("\n");
 }
 
+void print_bool_val(const char *name, const char *json_name, bool val, bool addcomma) {
+    if (print_json) {
+        printf("\"%s\": ", json_name);
+    } else {
+        printf("%s: ", name);
+    }
+    printf("%s", val ? "true" : "false");
+    if (print_json) {
+        if (addcomma) {
+            printf(",");
+        }
+    }
+    printf("\n");
+}
+
 void print_int_val(const char *name, const char *json_name, const char *valfmt, int val, bool addcomma) {
     if (print_json) {
         printf("\"%s\": \"", json_name);

--- a/src/printjson.c
+++ b/src/printjson.c
@@ -1,0 +1,61 @@
+#include <ApplicationServices/ApplicationServices.h>
+#include <stdio.h>
+
+bool print_json = false;
+
+void print_json_start(char type, const char *name) {
+    if (!print_json) {
+        return;
+    }
+    if (name) {
+        printf("\"%s\": ", name);
+    }
+    printf("%c\n", type);
+}
+
+void print_plain_nl() {
+    if (!print_json) {
+        printf("\n");
+    }
+}
+void print_json_end(char type, bool addcomma) {
+    if (print_json) {
+        printf("%c", type);
+        if (addcomma) {
+            printf(",");
+        }
+        printf("\n");
+    }
+}
+
+void print_str_val(const char *name, const char *json_name, const char *valfmt, const char *val, bool addcomma) {
+    if (print_json) {
+        printf("\"%s\": \"", json_name);
+    } else {
+        printf("%s: ", name);
+    }
+    printf(valfmt, val);
+    if (print_json) {
+        printf("\"");
+        if (addcomma) {
+            printf(",");
+        }
+    }
+    printf("\n");
+}
+
+void print_int_val(const char *name, const char *json_name, const char *valfmt, int val, bool addcomma) {
+    if (print_json) {
+        printf("\"%s\": \"", json_name);
+    } else {
+        printf("%s: ", name);
+    }
+    printf(valfmt, val);
+    if (print_json) {
+        printf("\"");
+        if (addcomma) {
+            printf(",");
+        }
+    }
+    printf("\n");
+}

--- a/src/printjson.h
+++ b/src/printjson.h
@@ -1,0 +1,9 @@
+#pragma once
+
+extern bool print_json;
+
+void print_plain_nl();
+void print_json_start(char type, const char *name);
+void print_json_end(char type, bool addcomma);
+void print_str_val(const char *name, const char *json_name, const char *valfmt, const char *val, bool addcomma);
+void print_int_val(const char *name, const char *json_name, const char *valfmt, int val, bool addcomma);

--- a/src/printjson.h
+++ b/src/printjson.h
@@ -7,3 +7,4 @@ void print_json_start(char type, const char *name);
 void print_json_end(char type, bool addcomma);
 void print_str_val(const char *name, const char *json_name, const char *valfmt, const char *val, bool addcomma);
 void print_int_val(const char *name, const char *json_name, const char *valfmt, int val, bool addcomma);
+void print_bool_val(const char *name, const char *json_name, bool val, bool addcomma);


### PR DESCRIPTION
Addressing #141 - this adds JSON output to the `list` command when adding the `--json` flag.

I tried my best to keep the normal list output exactly the same as the last version available on homebrew:

```shell
$ displayplacer --version
displayplacer v1.4.0

Developer: Jake Hilborn
GitHub: https://github.com/jakehilborn/displayplacer
LinkedIn: https://www.linkedin.com/in/jakehilborn
Email: jakehilborn@gmail
$ displayplacer list > list_old
$ make && ./displayplacer list > list_new
$ diff list_new list_old
$
```

No attempt has been made to format the JSON output, I leave that to external tools like `jq`.